### PR TITLE
Track create-table and drop-table events with Datasette 1.0a8

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,4 +32,3 @@ jobs:
     - name: Run tests
       run: |
         pytest
-

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        datasette-version: ["<1.0", ">=1.0a8"]
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
@@ -27,6 +28,7 @@ jobs:
     - name: Install dependencies
       run: |
         pip install -e '.[test]'
+        pip install "datasette${{ matrix.datasette-version }}"
     - name: Run tests
       run: |
         pytest

--- a/datasette_edit_schema/__init__.py
+++ b/datasette_edit_schema/__init__.py
@@ -602,6 +602,13 @@ async def drop_table(request, datasette, database, table):
 
     await datasette.databases[database.name].execute_write_fn(do_drop_table, block=True)
     datasette.add_message(request, "Table has been deleted")
+    await track_event(
+        datasette,
+        "DropTableEvent",
+        actor=request.actor,
+        database=database.name,
+        table=table,
+    )
     return Response.redirect("/-/edit-schema/" + database.name)
 
 

--- a/datasette_edit_schema/__init__.py
+++ b/datasette_edit_schema/__init__.py
@@ -11,8 +11,20 @@ from .utils import (
     potential_primary_keys,
 )
 
+try:
+    from datasette import events
+except ImportError:  # Pre Datasette 1.0a8
+    events = None
+
 # Don't attempt to detect foreign keys on tables larger than this:
 FOREIGN_KEY_DETECTION_LIMIT = 10_000
+
+
+async def track_event(datasette, klass_name, **kwargs):
+    if not hasattr(datasette, "track_event"):
+        return
+    klass = getattr(events, klass_name)
+    await datasette.track_event(klass(**kwargs))
 
 
 @hookimpl
@@ -245,17 +257,18 @@ async def edit_schema_create_table(request, datasette):
         def create_the_table(conn):
             db = sqlite_utils.Database(conn)
             if not table_name.strip():
-                return "Table name is required"
+                return None, "Table name is required"
             if db[table_name].exists():
-                return "Table already exists"
+                return None, "Table already exists"
             try:
                 db[table_name].create(
                     create, pk=primary_key_name, not_null=(primary_key_name,)
                 )
+                return db[table_name].schema, None
             except Exception as e:
-                return str(e)
+                return None, str(e)
 
-        error = await db.execute_write_fn(create_the_table, block=True)
+        schema, error = await db.execute_write_fn(create_the_table, block=True)
 
         if error:
             datasette.add_message(request, str(error), datasette.ERROR)
@@ -263,6 +276,14 @@ async def edit_schema_create_table(request, datasette):
         else:
             datasette.add_message(request, "Table has been created")
             path = datasette.urls.table(database_name, table_name)
+            await track_event(
+                datasette,
+                "CreateTableEvent",
+                actor=request.actor,
+                database=database_name,
+                table=table_name,
+                schema=schema,
+            )
 
         return Response.redirect(path)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -153,3 +153,19 @@ def permission_plugin():
     pm.register(PermissionPlugin(), name="undo_permission_plugin")
     yield
     pm.unregister(name="undo_permission_plugin")
+
+
+class TrackEventPlugin:
+    __name__ = "TrackEventPlugin"
+
+    @hookimpl
+    def track_event(self, datasette, event):
+        datasette._tracked_events = getattr(datasette, "_tracked_events", [])
+        datasette._tracked_events.append(event)
+
+
+@pytest.fixture(scope="session", autouse=True)
+def install_event_tracking_plugin():
+    from datasette.plugins import pm
+
+    pm.register(TrackEventPlugin(), name="TrackEventPlugin")

--- a/tests/test_edit_schema.py
+++ b/tests/test_edit_schema.py
@@ -14,6 +14,13 @@ from .conftest import Rule
 whitespace = re.compile(r"\s+")
 
 
+def get_last_event(datasette):
+    # Returns None of events are not tracked
+    events = getattr(datasette, "_tracked_events", [])
+    if events:
+        return events[-1]
+
+
 @pytest.mark.asyncio
 async def test_csrf_required(db_path):
     ds = Datasette([db_path])
@@ -923,6 +930,9 @@ async def test_create_table(db_path, post_data, expected_message, expected_schem
     if expected_schema is not None:
         db = sqlite_utils.Database(db_path)
         assert db[post_data["table_name"]].columns_dict == expected_schema
+    event = get_last_event(ds)
+    if event:
+        assert event.name == "create-table"
 
 
 def test_examples_for_columns():


### PR DESCRIPTION
Refs:
- #50

TODO:
- [x] Run tests on both Datasette versions
- [x] Track create table
- [x] Track drop table
- [x] Tests for all the above that only run on Datasette 1.0a8